### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 This MCP server provides a Python REPL (Read-Eval-Print Loop) as a tool. It allows execution of Python code through the MCP protocol with a persistent session.
 
+<a href="https://glama.ai/mcp/servers/jsorljnhdl">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/jsorljnhdl/badge" alt="Python REPL Server MCP server" />
+</a>
+
 ## Setup
 
 No setup needed! The project uses `uv` for dependency management.


### PR DESCRIPTION
This PR adds a badge for the [Python REPL MCP Server](https://glama.ai/mcp/servers/jsorljnhdl) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/jsorljnhdl">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/jsorljnhdl/badge" alt="Python REPL Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.