### PR TITLE
docs: fix setup instructions and add fallback for non-working entry point

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,19 @@ This MCP server provides a Python REPL (Read-Eval-Print Loop) as a tool. It allo
 
 ## Setup
 
-No setup needed! The project uses `uv` for dependency management.
-
+### Prerequisites
+- Install `uv` if you haven't already
+- Clone this repository
+```bash
+git clone https://github.com/hdresearch/mcp-python
+```
 ## Running the Server
 
 Simply run:
 
 ```bash
-uv run src/python_repl/server.py
+cd mcp-python
+uv run src/mcp_python/server.py
 ```
 
 ## Usage with Claude Desktop
@@ -25,7 +30,7 @@ Add this configuration to your Claude Desktop config file:
       "command": "uv",
       "args": [
         "--directory",
-        "/absolute/path/to/python-repl-server",
+        "/absolute/path/to/mcp-python",
         "run",
         "mcp_python"
       ]
@@ -33,6 +38,10 @@ Add this configuration to your Claude Desktop config file:
   }
 }
 ```
+
+- `/absolute/path/to/mcp-python` might look like `/Users/hdresearch/repos/mcp-python`
+- if `mcp_python` is not working, substitute with `src/mcp_python/server.py`
+
 
 The server provides three tools:
 


### PR DESCRIPTION
- Added Prerequisites section with setup steps
- Corrected paths and commands in Claude Desktop config 
- Added working fallback (`src/mcp_python/server.py`) for when `mcp_python` entry point doesn't work